### PR TITLE
New Team Creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2220,153 +2220,6 @@
         "tslint": "^5.20.1",
         "webpack": "^4.0.0",
         "yorkie": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true
-        },
-        "fork-ts-checker-webpack-plugin-v5": {
-          "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
-          "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
-          "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@babel/code-frame": "^7.8.3",
-            "@types/json-schema": "^7.0.5",
-            "chalk": "^4.1.0",
-            "cosmiconfig": "^6.0.0",
-            "deepmerge": "^4.2.2",
-            "fs-extra": "^9.0.0",
-            "memfs": "^3.1.2",
-            "minimatch": "^3.0.4",
-            "schema-utils": "2.7.0",
-            "semver": "^7.3.2",
-            "tapable": "^1.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "schema-utils": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@types/json-schema": "^7.0.4",
-            "ajv": "^6.12.2",
-            "ajv-keywords": "^3.4.1"
-          }
-        },
-        "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "dev": true,
-          "optional": true
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "@vue/cli-plugin-unit-jest": {
@@ -2530,17 +2383,6 @@
             "unique-filename": "^1.1.1"
           }
         },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -2598,18 +2440,6 @@
           "requires": {
             "merge-stream": "^2.0.0",
             "supports-color": "^7.0.0"
-          }
-        },
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
           }
         },
         "p-map": {
@@ -2672,18 +2502,6 @@
             "source-map": "^0.6.1",
             "terser": "^4.6.12",
             "webpack-sources": "^1.4.3"
-          }
-        },
-        "vue-loader-v16": {
-          "version": "npm:vue-loader@16.1.2",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
-          "integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chalk": "^4.1.0",
-            "hash-sum": "^2.0.0",
-            "loader-utils": "^2.0.0"
           }
         },
         "wrap-ansi": {
@@ -7606,6 +7424,153 @@
         "semver": "^5.6.0",
         "tapable": "^1.0.0",
         "worker-rpc": "^0.1.0"
+      }
+    },
+    "fork-ts-checker-webpack-plugin-v5": {
+      "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
+      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
+      "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@types/json-schema": "^7.0.5",
+        "chalk": "^4.1.0",
+        "cosmiconfig": "^6.0.0",
+        "deepmerge": "^4.2.2",
+        "fs-extra": "^9.0.0",
+        "memfs": "^3.1.2",
+        "minimatch": "^3.0.4",
+        "schema-utils": "2.7.0",
+        "semver": "^7.3.2",
+        "tapable": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "schema-utils": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true,
+          "optional": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "form-data": {
@@ -18952,6 +18917,87 @@
           "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
+        }
+      }
+    },
+    "vue-loader-v16": {
+      "version": "npm:vue-loader@16.1.2",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
+      "integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "hash-sum": "^2.0.0",
+        "loader-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
+    "serve-prod": "vue-cli-service serve --mode production",
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",
     "test:e2e": "vue-cli-service test:e2e",

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -14,52 +14,29 @@ export interface SignupDetails {
 }
 
 // MARK: Authentication Methods
-export async function signup(details: SignupDetails, axios: AxiosInstance) {
-  const p = new Promise<string>(function(success, fail) {
-    axios
-      .post("/auth/registration/", {
-        username: details.username,
-        email: details.email,
-        password1: details.password,
-        password2: details.secondaryPassword
-      })
-      .then(response => {
-        console.log("Successful signup! Printing response data...");
-        console.log(response.data);
-
-        success(response.data.key as string);
-      })
-      .catch(error => {
-        console.log("Error signing up. Printing response data:");
-        console.log(error.response.data);
-
-        fail(undefined);
-      });
+export async function signup(
+  details: SignupDetails,
+  axios: AxiosInstance
+): Promise<string> {
+  const response = await axios.post("/auth/registration/", {
+    username: details.username,
+    email: details.email,
+    password1: details.password,
+    password2: details.secondaryPassword
   });
 
-  return p;
+  const responseData = response.data;
+
+  return responseData.key;
 }
 
 export async function login(
   details: LoginDetails,
   axios: AxiosInstance
 ): Promise<string> {
-  const p = new Promise<string>(function(success, fail) {
-    axios
-      .post("/auth/login/", details)
-      .then(response => {
-        console.log("Successful login! Printing response key:");
-        console.log(response.data);
+  const response = await axios.post("/auth/login/", details);
+  console.log("Successful login! Printing response key:");
+  console.log(response.data);
 
-        success(response.data.key as string);
-      })
-      .catch(error => {
-        console.log("Login not successful. Printing response...");
-        console.log(error.response.data);
-
-        fail(undefined);
-      });
-  });
-
-  return p;
+  return response.data.key as string;
 }

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,4 +1,4 @@
-import { generateAxiosInstance } from "./base";
+import { AxiosInstance } from "axios";
 
 // MARK: Interfaces
 export interface LoginDetails {
@@ -14,8 +14,7 @@ export interface SignupDetails {
 }
 
 // MARK: Authentication Methods
-export async function signup(details: SignupDetails) {
-  const axios = generateAxiosInstance();
+export async function signup(details: SignupDetails, axios: AxiosInstance) {
   const p = new Promise<string>(function(success, fail) {
     axios
       .post("/auth/registration/", {
@@ -41,9 +40,10 @@ export async function signup(details: SignupDetails) {
   return p;
 }
 
-export async function login(details: LoginDetails): Promise<string> {
-  const axios = generateAxiosInstance();
-
+export async function login(
+  details: LoginDetails,
+  axios: AxiosInstance
+): Promise<string> {
   const p = new Promise<string>(function(success, fail) {
     axios
       .post("/auth/login/", details)

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 
 export function generateAxiosInstance(token?: string) {
   const instance = axios.create({
@@ -9,6 +9,35 @@ export function generateAxiosInstance(token?: string) {
     config.headers.Authorization = token ? `Bearer ${token}` : "";
     return config;
   });
+
+  // TODO: Expand below into properly reporting such errors on the frontend
+  // This can probably be done centrally if most code that chains simply
+  // stops. Noting, this means that bad chains of actions may partially complete
+  // this is probably fine but could be looked into later.
+  instance.interceptors.response.use(
+    function(response) {
+      return response;
+    },
+    function(e) {
+      if (e.isAxiosError) {
+        const error = e as AxiosError;
+        console.log(`Error occurred!`);
+        console.log(`Printing error details: `);
+        if (error.response) {
+          console.log(
+            `Got bad status ${error.response.status}: ${error.response.statusText}`
+          );
+          console.log(error.response.data);
+        } else if (error.request) {
+          console.log(error.request);
+        } else {
+          console.log("Unable to print details.");
+        }
+      }
+
+      return e;
+    }
+  );
 
   return instance;
 }

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 
 export function generateAxiosInstance() {
   const instance = axios.create({
-    baseURL: "http://localhost:8080/"
+    baseURL: "http://127.0.0.1:8080/"
   }); // TODO: This is hardwired and bad
 
   return instance;

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -1,9 +1,14 @@
 import axios from "axios";
 
-export function generateAxiosInstance() {
+export function generateAxiosInstance(token?: string) {
   const instance = axios.create({
     baseURL: "http://127.0.0.1:8080/"
   }); // TODO: This is hardwired and bad
+
+  instance.interceptors.request.use(config => {
+    config.headers.Authorization = token ? `Bearer ${token}` : "";
+    return config;
+  });
 
   return instance;
 }

--- a/src/api/statuses.ts
+++ b/src/api/statuses.ts
@@ -1,4 +1,4 @@
-import { AxiosInstance, AxiosPromise } from "axios";
+import { AxiosInstance } from "axios";
 import { TeamRecord } from "@/api/teams";
 
 export interface NewStatusRecord {
@@ -14,26 +14,23 @@ export interface StatusRecord {
   deactivated: string;
 }
 
-function get(
+export async function getStatus(
   axios: AxiosInstance,
   team: TeamRecord
-): AxiosPromise<StatusRecord> {
-  return axios.get(`/api/teams/${team.id}/statuses/`);
+): Promise<StatusRecord> {
+  const response = await axios.get(`/api/teams/${team.id}/statuses/`);
+  return response.data as StatusRecord;
 }
 
-function post(
+export async function postStatus(
   axios: AxiosInstance,
   team: TeamRecord,
   title: string
-): AxiosPromise<StatusRecord> {
+): Promise<StatusRecord> {
   const record: NewStatusRecord = {
     title
   };
 
-  return axios.post(`/api/teams/${team.id}/statuses/`, record);
+  const response = await axios.post(`/api/teams/${team.id}/statuses/`, record);
+  return response.data as StatusRecord;
 }
-
-export default {
-  get,
-  post
-};

--- a/src/api/statuses.ts
+++ b/src/api/statuses.ts
@@ -1,0 +1,39 @@
+import { AxiosInstance, AxiosPromise } from "axios";
+import { TeamRecord } from "@/api/teams";
+
+export interface NewStatusRecord {
+  title: string;
+}
+
+export interface StatusRecord {
+  id: number;
+  object_uuid: string;
+  title: string;
+  created: string;
+  activated: string;
+  deactivated: string;
+}
+
+function get(
+  axios: AxiosInstance,
+  team: TeamRecord
+): AxiosPromise<StatusRecord> {
+  return axios.get(`/api/teams/${team.id}/statuses/`);
+}
+
+function post(
+  axios: AxiosInstance,
+  team: TeamRecord,
+  title: string
+): AxiosPromise<StatusRecord> {
+  const record: NewStatusRecord = {
+    title
+  };
+
+  return axios.post(`/api/teams/${team.id}/statuses/`, record);
+}
+
+export default {
+  get,
+  post
+};

--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -1,5 +1,4 @@
-import { AxiosPromise } from "axios";
-import { generateAxiosInstance } from "./base";
+import { AxiosInstance, AxiosPromise } from "axios";
 
 // Team API endpoints
 export interface NewTeamRecord {
@@ -18,9 +17,10 @@ export interface TeamRecord {
   deactivated: string;
 }
 
-export function postTeam(record: NewTeamRecord): AxiosPromise {
-  const axios = generateAxiosInstance();
-
+export function postTeam(
+  record: NewTeamRecord,
+  axios: AxiosInstance
+): AxiosPromise {
   return axios.post("/api/teams/", {
     name: record.name,
     description: "UNUSED"

--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -1,0 +1,28 @@
+import { AxiosPromise } from "axios";
+import { generateAxiosInstance } from "./base";
+
+// Team API endpoints
+export interface NewTeamRecord {
+  name: string;
+  description: string;
+}
+
+export interface TeamRecord {
+  id: number;
+  name: string;
+  description: string;
+  object_uuid: string;
+  ticket_head: number;
+  created: string;
+  activated: string;
+  deactivated: string;
+}
+
+export function postTeam(record: NewTeamRecord): AxiosPromise {
+  const axios = generateAxiosInstance();
+
+  return axios.post("/api/teams/", {
+    name: record.name,
+    description: "UNUSED"
+  });
+}

--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -1,4 +1,5 @@
-import { AxiosInstance, AxiosPromise } from "axios";
+import { AxiosInstance } from "axios";
+import { postStatus } from "@/api/statuses";
 
 // Team API endpoints
 export interface NewTeamRecord {
@@ -17,19 +18,39 @@ export interface TeamRecord {
   deactivated: string;
 }
 
-export function postTeam(
+export async function postTeam(
   record: NewTeamRecord,
   axios: AxiosInstance
-): AxiosPromise<TeamRecord> {
-  return axios.post("/api/teams/", {
+): Promise<TeamRecord> {
+  const response = await axios.post("/api/teams/", {
     name: record.name,
     description: "UNUSED"
   });
+
+  return response.data as TeamRecord;
 }
 
-export function getTeam(
+export async function createTeam(
+  axios: AxiosInstance,
+  record: NewTeamRecord
+): Promise<TeamRecord> {
+  const newTeamRecord = await postTeam(record, axios);
+
+  try {
+    await postStatus(axios, newTeamRecord, "To Do");
+    await postStatus(axios, newTeamRecord, "In Progress");
+    await postStatus(axios, newTeamRecord, "Completed");
+  } catch (e) {
+    console.log("There was an error setting initial team status.");
+  }
+
+  return newTeamRecord;
+}
+
+export async function getTeam(
   axios: AxiosInstance,
   teamId: number
-): AxiosPromise<TeamRecord> {
-  return axios.get(`/api/teams/${teamId}/`);
+): Promise<TeamRecord> {
+  const response = await axios.get(`/api/teams/${teamId}/`);
+  return response.data as TeamRecord;
 }

--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -26,3 +26,10 @@ export function postTeam(
     description: "UNUSED"
   });
 }
+
+export function getTeam(
+  axios: AxiosInstance,
+  teamId: number
+): AxiosPromise<TeamRecord> {
+  return axios.get(`/api/teams/${teamId}/`);
+}

--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -20,7 +20,7 @@ export interface TeamRecord {
 export function postTeam(
   record: NewTeamRecord,
   axios: AxiosInstance
-): AxiosPromise {
+): AxiosPromise<TeamRecord> {
   return axios.post("/api/teams/", {
     name: record.name,
     description: "UNUSED"

--- a/src/components/SluggoNavbar.vue
+++ b/src/components/SluggoNavbar.vue
@@ -1,9 +1,9 @@
 <template>
   <nav class="navbar is-link" role="navigation" aria-label="main navigation">
     <div class="navbar-brand">
-      <router-link class="navbar-item" to="/">
+      <navbar-team-page-link class="navbar-item" destination="">
         <h1 class=" is-size-3 has-text-weight-bold">Sluggo</h1>
-      </router-link>
+      </navbar-team-page-link>
       <a
         role="button"
         class="navbar-burger burger"
@@ -19,15 +19,15 @@
     </div>
     <div id="left-navbar" class="navbar-menu">
       <div class="navbar-start">
-        <router-link class="navbar-item" to="/tickets">
+        <navbar-team-page-link class="navbar-item" destination="tickets">
           <span class="navbar-item-name is-size-4">Tickets</span>
-        </router-link>
-        <router-link class="navbar-item" to="/users">
+        </navbar-team-page-link>
+        <navbar-team-page-link class="navbar-item" destination="users">
           <span class="navbar-item-name is-size-4">Users</span>
-        </router-link>
-        <router-link class="navbar-item" to="/admin">
+        </navbar-team-page-link>
+        <navbar-team-page-link class="navbar-item" destination="admin">
           <span class="navbar-item-name is-size-4">Admin</span>
-        </router-link>
+        </navbar-team-page-link>
         <router-link class="navbar-item" to="/help">
           <span class="navbar-item-name is-size-4">Help</span>
         </router-link>
@@ -65,8 +65,13 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 
+import NavbarTeamPageLink from "@/components/navbar/NavbarTeamPageLink.vue";
+
 const sluggoNavbarComponent = defineComponent({
-  name: "SluggoNavbar"
+  name: "SluggoNavbar",
+  components: {
+    NavbarTeamPageLink
+  }
 });
 
 export default sluggoNavbarComponent;

--- a/src/components/SluggoNavbar.vue
+++ b/src/components/SluggoNavbar.vue
@@ -40,6 +40,9 @@
               <img src="" />
             </a>
             <div class="navbar-dropdown is-boxed is-size-4">
+              <router-link class="navbar-item" to="/new_team">
+                Create Team
+              </router-link>
               <router-link class="navbar-item" to="/login">
                 Logout
               </router-link>

--- a/src/components/TeamWrapper.vue
+++ b/src/components/TeamWrapper.vue
@@ -1,0 +1,13 @@
+<template>
+  <router-view />
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+const teamWrapperComponent = defineComponent({
+  name: "TeamWrapper"
+});
+
+export default teamWrapperComponent;
+</script>

--- a/src/components/navbar/NavbarTeamPageLink.vue
+++ b/src/components/navbar/NavbarTeamPageLink.vue
@@ -7,6 +7,7 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 import { useRouter } from "vue-router";
+import { generateTeamPageLink } from "@/methods/teamPage";
 import store from "@/store";
 
 const navbarPageLinkComponent = defineComponent({
@@ -33,7 +34,12 @@ const navbarPageLinkComponent = defineComponent({
         return;
       }
 
-      router.push("/teams/" + record.id + "/" + props.destination);
+      router.push(
+        generateTeamPageLink(
+          record,
+          props.destination !== "" ? props.destination : undefined
+        )
+      );
     };
 
     return {

--- a/src/components/navbar/NavbarTeamPageLink.vue
+++ b/src/components/navbar/NavbarTeamPageLink.vue
@@ -1,0 +1,46 @@
+<template>
+  <a @click.prevent="navigate()" href="#">
+    <slot></slot>
+  </a>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { useRouter } from "vue-router";
+import store from "@/store";
+
+const navbarPageLinkComponent = defineComponent({
+  name: "NavbarPageLink",
+  props: {
+    destination: {
+      type: String,
+      required: true
+    }
+  },
+  setup(props) {
+    const router = useRouter();
+
+    const navigate = () => {
+      // Get team record from store and verify
+      const record = store.state.team;
+
+      if (typeof record === "undefined") {
+        console.warn(
+          "Note: Team was not set when attempting to navigate to a team page. Navigating to /login instead."
+        );
+
+        router.push("/login");
+        return;
+      }
+
+      router.push("/teams/" + record.id + "/" + props.destination);
+    };
+
+    return {
+      navigate
+    };
+  }
+});
+
+export default navbarPageLinkComponent;
+</script>

--- a/src/methods/teamPage.ts
+++ b/src/methods/teamPage.ts
@@ -1,0 +1,5 @@
+import { TeamRecord } from "@/api/teams";
+
+export function generateTeamPageLink(team: TeamRecord, loc?: string) {
+  return `/teams/${team.id}` + (typeof loc !== "undefined" ? `/${loc}/` : ``);
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -7,6 +7,7 @@ import Help from "@/views/Help.vue";
 import Auth from "@/views/Auth.vue";
 import Profile from "@/views/Profile.vue";
 import TicketDetails from "@/views/TicketDetails.vue";
+import NewTeam from "@/views/NewTeam.vue";
 
 const routes: Array<RouteRecordRaw> = [
   {
@@ -48,6 +49,11 @@ const routes: Array<RouteRecordRaw> = [
     path: "/tickets/:id",
     name: "TicketDetails",
     component: TicketDetails
+  },
+  {
+    path: "/new_team/",
+    name: "NewTeam",
+    component: NewTeam
   }
   // {
   //   path: "/about",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -8,33 +8,71 @@ import Auth from "@/views/Auth.vue";
 import Profile from "@/views/Profile.vue";
 import TicketDetails from "@/views/TicketDetails.vue";
 import NewTeam from "@/views/NewTeam.vue";
+import TeamWrapper from "@/components/TeamWrapper.vue";
 
 const routes: Array<RouteRecordRaw> = [
   {
-    path: "/",
-    name: "Home",
-    component: Home
+    path: "/teams/:teamId",
+    name: "Team",
+    component: TeamWrapper,
+    children: [
+      {
+        path: "",
+        name: "Home",
+        component: Home
+      },
+      {
+        path: "tickets",
+        name: "Tickets",
+        component: Tickets
+      },
+      {
+        path: "users",
+        name: "Users",
+        component: Users
+      },
+      {
+        path: "users/:userId",
+        name: "Profile",
+        component: Profile
+      },
+      {
+        path: "admin",
+        name: "Admin",
+        component: Admin
+      },
+      {
+        path: "tickets/:userId",
+        name: "TicketDetails",
+        component: TicketDetails
+      }
+    ]
   },
-  {
-    path: "/tickets",
-    name: "Tickets",
-    component: Tickets
-  },
-  {
-    path: "/users",
-    name: "Users",
-    component: Users
-  },
-  {
-    path: "/users/:id",
-    name: "Profile",
-    component: Profile
-  },
-  {
-    path: "/admin",
-    name: "Admin",
-    component: Admin
-  },
+  // {
+  //   path: "/",
+  //   name: "Home",
+  //   component: Home
+  // },
+  // {
+  //   path: "/tickets",
+  //   name: "Tickets",
+  //   component: Tickets
+  // },
+  // {
+  //   path: "/users",
+  //   name: "Users",
+  //   component: Users
+  // },
+  // {
+  //   path: "/users/:id",
+  //   name: "Profile",
+  //   component: Profile
+  // },
+  // {
+  //   path: "/admin",
+  //   name: "Admin",
+  //   component: Admin
+  // },
   {
     path: "/help",
     name: "Help",
@@ -45,11 +83,11 @@ const routes: Array<RouteRecordRaw> = [
     name: "Auth",
     component: Auth
   },
-  {
-    path: "/tickets/:id",
-    name: "TicketDetails",
-    component: TicketDetails
-  },
+  // {
+  //   path: "/tickets/:id",
+  //   name: "TicketDetails",
+  //   component: TicketDetails
+  // },
   {
     path: "/new_team/",
     name: "NewTeam",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,6 @@
 import { createDirectStore } from "direct-vuex";
 import { SignupDetails, LoginDetails, signup, login } from "@/api/auth";
+import { TeamRecord, NewTeamRecord, postTeam } from "@/api/teams";
 
 interface RootStoreState {
   token?: string;
@@ -33,6 +34,12 @@ const {
     },
     doLogout(context) {
       rootActionContext(context).commit.setToken(undefined);
+    },
+    doCreateTeam(context, record: NewTeamRecord) {
+      postTeam(record).then(response => {
+        const record = response.data as TeamRecord;
+        console.log(record);
+      });
     }
   },
   modules: {},

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,6 +1,7 @@
 import { createDirectStore } from "direct-vuex";
 import { SignupDetails, LoginDetails, signup, login } from "@/api/auth";
 import { TeamRecord, NewTeamRecord, postTeam } from "@/api/teams";
+import { generateAxiosInstance } from "@/api/base";
 
 interface RootStoreState {
   token?: string;
@@ -22,21 +23,30 @@ const {
     }
   },
   actions: {
-    doSignup(context, details: SignupDetails) {
-      signup(details).then(key => {
-        rootActionContext(context).commit.setToken(key);
+    doSignup(ctxRaw, details: SignupDetails) {
+      const context = rootActionContext(ctxRaw);
+      const axios = generateAxiosInstance(context.state.token);
+
+      signup(details, axios).then(key => {
+        context.commit.setToken(key);
       });
     },
-    doLogin(context, details: LoginDetails) {
-      login(details).then(key => {
-        rootActionContext(context).commit.setToken(key);
+    doLogin(ctxRaw, details: LoginDetails) {
+      const context = rootActionContext(ctxRaw);
+      const axios = generateAxiosInstance(context.state.token);
+      login(details, axios).then(key => {
+        context.commit.setToken(key);
       });
     },
-    doLogout(context) {
-      rootActionContext(context).commit.setToken(undefined);
+    doLogout(ctxRaw) {
+      const context = rootActionContext(ctxRaw);
+      context.commit.setToken(undefined);
     },
-    doCreateTeam(context, record: NewTeamRecord) {
-      postTeam(record).then(response => {
+    doCreateTeam(ctxRaw, record: NewTeamRecord) {
+      const context = rootActionContext(ctxRaw);
+      const axios = generateAxiosInstance(context.state.token);
+
+      postTeam(record, axios).then(response => {
         const record = response.data as TeamRecord;
         console.log(record);
       });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,11 +1,12 @@
 import { createDirectStore } from "direct-vuex";
 import { SignupDetails, LoginDetails, signup, login } from "@/api/auth";
-import { TeamRecord, NewTeamRecord, postTeam } from "@/api/teams";
+import { TeamRecord, NewTeamRecord, postTeam, getTeam } from "@/api/teams";
 import { generateAxiosInstance } from "@/api/base";
 import Statuses from "@/api/statuses";
 
 interface RootStoreState {
   token?: string;
+  team?: TeamRecord;
 }
 
 const {
@@ -21,6 +22,9 @@ const {
   mutations: {
     setToken(state, newToken: string | undefined) {
       state.token = newToken;
+    },
+    setTeam(state, newTeam: TeamRecord) {
+      state.team = newTeam;
     }
   },
   actions: {
@@ -69,6 +73,22 @@ const {
             console.log(error.response.data);
           });
       });
+    },
+    doSetTeam(ctxRaw, teamId: number) {
+      const context = rootActionContext(ctxRaw);
+      const axios = generateAxiosInstance(context.state.token);
+
+      getTeam(axios, teamId)
+        .then(response => {
+          const record = response.data;
+          context.commit.setTeam(record);
+
+          console.log(context.state.team);
+        })
+        .catch(error => {
+          console.log("Error setting team! Printing error details...");
+          console.log(error.response.data);
+        });
     }
   },
   modules: {},

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,6 +2,7 @@ import { createDirectStore } from "direct-vuex";
 import { SignupDetails, LoginDetails, signup, login } from "@/api/auth";
 import { TeamRecord, NewTeamRecord, postTeam } from "@/api/teams";
 import { generateAxiosInstance } from "@/api/base";
+import Statuses from "@/api/statuses";
 
 interface RootStoreState {
   token?: string;
@@ -47,8 +48,26 @@ const {
       const axios = generateAxiosInstance(context.state.token);
 
       postTeam(record, axios).then(response => {
-        const record = response.data as TeamRecord;
-        console.log(record);
+        const newTeamRecord = response.data;
+        console.log(newTeamRecord);
+
+        // Put team into a good state
+        // This would probably be a good idea to standardize on the
+        // backend, but I don't want to wait on backend
+        Promise.all([
+          Statuses.post(axios, newTeamRecord, "To Do"),
+          Statuses.post(axios, newTeamRecord, "In Progress"),
+          Statuses.post(axios, newTeamRecord, "Completed")
+        ])
+          .then(() => {
+            console.log("Statuses created!");
+          })
+          .catch(error => {
+            console.log(
+              "Error encountered setting up initial team state. Printing..."
+            );
+            console.log(error.response.data);
+          });
       });
     }
   },

--- a/src/views/Auth.vue
+++ b/src/views/Auth.vue
@@ -68,7 +68,9 @@
 
 <script lang="ts">
 import { defineComponent, ref, computed } from "vue";
+import { useRouter } from "vue-router";
 import store from "@/store";
+import { generateTeamPageLink } from "@/methods/teamPage";
 
 export default defineComponent({
   name: "Auth",
@@ -80,6 +82,8 @@ export default defineComponent({
     const teamId = ref(0);
 
     const key = computed(() => store.state.token);
+
+    const router = useRouter();
 
     const login = () => {
       store.dispatch.doLogin({
@@ -102,7 +106,9 @@ export default defineComponent({
     };
 
     const setTeam = () => {
-      store.dispatch.doSetTeam(teamId.value);
+      store.dispatch.doSetTeam(teamId.value).then(response => {
+        router.push(generateTeamPageLink(response));
+      });
     };
 
     return {

--- a/src/views/Auth.vue
+++ b/src/views/Auth.vue
@@ -52,6 +52,18 @@
       </form>
     </div>
   </section>
+  <section class="section">
+    <h1 class="title">Team Control</h1>
+    <p>Note: Requires authentication</p>
+
+    <form @submit.prevent="setTeam">
+      <label for="teamId">Team ID </label>
+      <input type="number" name="teamId" v-model="teamId" placeholder="0" />
+      <br />
+
+      <button>Set Team</button>
+    </form>
+  </section>
 </template>
 
 <script lang="ts">
@@ -65,6 +77,7 @@ export default defineComponent({
     const email = ref("");
     const password = ref("");
     const secondaryPassword = ref("");
+    const teamId = ref(0);
 
     const key = computed(() => store.state.token);
 
@@ -88,6 +101,10 @@ export default defineComponent({
       store.dispatch.doLogout();
     };
 
+    const setTeam = () => {
+      store.dispatch.doSetTeam(teamId.value);
+    };
+
     return {
       username,
       email,
@@ -96,6 +113,8 @@ export default defineComponent({
       login,
       signup,
       signout,
+      teamId,
+      setTeam,
       key
     };
   }

--- a/src/views/Auth.vue
+++ b/src/views/Auth.vue
@@ -10,11 +10,14 @@
         </em>
       </p>
       <p>
-        This page doesn't have responses for auth; please check the console to
-        see if anything went wrong
+        This page doesn't have error popups for authentication problems; please
+        check the console to see if anything went wrong
       </p>
       <br />
-      <p>Current Key: {{ key }}</p>
+      <p>
+        Current Key: {{ key }}
+        <strong>(will be deloaded if manually navigated or reloaded)</strong>
+      </p>
       <br />
       <form @submit.prevent="login">
         <label for="username">Username </label>
@@ -53,16 +56,18 @@
     </div>
   </section>
   <section class="section">
-    <h1 class="title">Team Control</h1>
-    <p>Note: Requires authentication</p>
+    <div class="container">
+      <h1 class="title">Team Control</h1>
+      <p>Note: Requires authentication</p>
 
-    <form @submit.prevent="setTeam">
-      <label for="teamId">Team ID </label>
-      <input type="number" name="teamId" v-model="teamId" placeholder="0" />
-      <br />
+      <form @submit.prevent="setTeam">
+        <label for="teamId">Team ID </label>
+        <input type="number" name="teamId" v-model="teamId" placeholder="0" />
+        <br />
 
-      <button>Set Team</button>
-    </form>
+        <button>Set Team</button>
+      </form>
+    </div>
   </section>
 </template>
 

--- a/src/views/Auth.vue
+++ b/src/views/Auth.vue
@@ -110,10 +110,9 @@ export default defineComponent({
       store.dispatch.doLogout();
     };
 
-    const setTeam = () => {
-      store.dispatch.doSetTeam(teamId.value).then(response => {
-        router.push(generateTeamPageLink(response));
-      });
+    const setTeam = async () => {
+      const teamRecord = await store.dispatch.doFetchAndSetTeam(teamId.value);
+      router.push(generateTeamPageLink(teamRecord));
     };
 
     return {

--- a/src/views/NewTeam.vue
+++ b/src/views/NewTeam.vue
@@ -42,6 +42,7 @@ import { defineComponent, ref } from "vue";
 import { useRouter } from "vue-router";
 
 import store from "@/store";
+import { createTeam } from "@/api/teams";
 
 import { generateTeamPageLink } from "@/methods/teamPage";
 
@@ -52,23 +53,15 @@ const newTeamComponent = defineComponent({
 
     const teamName = ref("");
 
-    const validateTeamName = () => {
-      return;
-    };
+    const teamSubmissionTriggered = async () => {
+      const record = await createTeam(store.getters.generateAxiosInstance, {
+        name: teamName.value.toLowerCase(),
+        description: "UNUSED"
+      });
 
-    const teamSubmissionTriggered = () => {
-      if (!validateTeamName) return;
+      await store.dispatch.doSetTeam(record);
 
-      store.dispatch
-        .doCreateTeam({
-          name: teamName.value.toLowerCase(),
-          description: "UNUSED"
-        })
-        .then(record =>
-          store.dispatch.doSetTeam(record.id).then(() => {
-            router.push(generateTeamPageLink(record));
-          })
-        );
+      router.push(generateTeamPageLink(record));
     };
 
     return {

--- a/src/views/NewTeam.vue
+++ b/src/views/NewTeam.vue
@@ -39,11 +39,17 @@
 
 <script lang="ts">
 import { defineComponent, ref } from "vue";
+import { useRouter } from "vue-router";
+
 import store from "@/store";
+
+import { generateTeamPageLink } from "@/methods/teamPage";
 
 const newTeamComponent = defineComponent({
   name: "NewTeam",
   setup: function() {
+    const router = useRouter();
+
     const teamName = ref("");
 
     const validateTeamName = () => {
@@ -53,10 +59,16 @@ const newTeamComponent = defineComponent({
     const teamSubmissionTriggered = () => {
       if (!validateTeamName) return;
 
-      store.dispatch.doCreateTeam({
-        name: teamName.value.toLowerCase(),
-        description: "UNUSED"
-      });
+      store.dispatch
+        .doCreateTeam({
+          name: teamName.value.toLowerCase(),
+          description: "UNUSED"
+        })
+        .then(record =>
+          store.dispatch.doSetTeam(record.id).then(() => {
+            router.push(generateTeamPageLink(record));
+          })
+        );
     };
 
     return {

--- a/src/views/NewTeam.vue
+++ b/src/views/NewTeam.vue
@@ -1,0 +1,70 @@
+<template>
+  <section class="section">
+    <div class="container">
+      <h1 class="title">Create a Team</h1>
+      <h2 class="subtitle">
+        Create a new team to hold all of your tickets, members, and more.
+      </h2>
+    </div>
+  </section>
+  <section class="section" id="create_team_form_section">
+    <div class="container">
+      <form @submit.prevent="teamSubmissionTriggered">
+        <div class="field">
+          <label class="label" for="team_name">Team Name </label>
+          <input
+            class="input"
+            type="text"
+            name="team_name"
+            placeholder="Team Name"
+            v-model="teamName"
+          />
+        </div>
+        <button class="button is-primary">
+          Create Team
+        </button>
+      </form>
+    </div>
+  </section>
+  <section class="section">
+    <div class="container">
+      <p>
+        When you create a new team, you will be made an owner of that team. This
+        will give you administrative permissions to manage the team.
+      </p>
+      <p>{{ teamName }}</p>
+    </div>
+  </section>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from "vue";
+import store from "@/store";
+
+const newTeamComponent = defineComponent({
+  name: "NewTeam",
+  setup: function() {
+    const teamName = ref("");
+
+    const validateTeamName = () => {
+      return;
+    };
+
+    const teamSubmissionTriggered = () => {
+      if (!validateTeamName) return;
+
+      store.dispatch.doCreateTeam({
+        name: teamName.value.toLowerCase(),
+        description: "UNUSED"
+      });
+    };
+
+    return {
+      teamName,
+      teamSubmissionTriggered
+    };
+  }
+});
+
+export default newTeamComponent;
+</script>

--- a/vue.config.js
+++ b/vue.config.js
@@ -2,7 +2,7 @@ module.exports = {
   devServer: {
     proxy: {
       "^/api": {
-        target: "http://localhost:8000/",
+        target: "http://127.0.0.1:8000/",
         ws: true,
         secure: false,
         changeOrigin: true
@@ -11,7 +11,7 @@ module.exports = {
         // }
       },
       "^/auth": {
-        target: "http://localhost:8000/",
+        target: "http://127.0.0.1:8000/",
         ws: true,
         secure: false,
         changeOrigin: true


### PR DESCRIPTION
This branch adds in the ability to:
* Create teams, with premade default statuses.
* Set the desired team in the temporary authentication page
* Teams are stored and tracked through the store
* Standardization of API access in a clean format, using async/await style syntax
* Error handling on Axios (enough for development)

Note that multi-team is still not supported; switching teams will require state modification in the central store. This is the best I could do, given the pains of retaining fully dynamic behaviors. In the production app, the app will load a team based on the URL (this is not currently done, since this would require persistent login, which is not yet implemented).