### PR TITLE
Tdimhcsleumas/ticket api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1664,6 +1664,12 @@
       "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
       "dev": true
     },
+    "@types/luxon": {
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-1.26.1.tgz",
+      "integrity": "sha512-VW+JT7SDiSKjQss7iX/3bB8CUwSqzhKuW8EcyhzFTb/mwbIkcm92cPmok5FDWYz5TskB/tWFK/mn2ByHCf44AQ==",
+      "dev": true
+    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -10618,6 +10624,11 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "luxon": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
+      "integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A=="
     },
     "magic-string": {
       "version": "0.25.7",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,14 @@
     "bulma": "^0.9.1",
     "core-js": "^3.6.5",
     "direct-vuex": "^0.12.1",
+    "luxon": "^1.26.0",
     "vue": "^3.0.0",
     "vue-router": "^4.0.0-0",
     "vuex": "^4.0.0-0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.19",
+    "@types/luxon": "^1.26.1",
     "@typescript-eslint/eslint-plugin": "^2.33.0",
     "@typescript-eslint/parser": "^2.33.0",
     "@vue/cli-plugin-babel": "~4.5.0",

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -48,3 +48,10 @@ export async function login(
 
   return response.data.key as string;
 }
+
+export async function getUser(
+  axios: AxiosInstance
+): Promise<UserRecord> {
+  const response = await axios.get("/auth/user/");
+  return response.data as UserRecord;
+}

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -13,6 +13,14 @@ export interface SignupDetails {
   secondaryPassword: string;
 }
 
+export interface UserRecord {
+  id: number;
+  email: string;
+  first_name: string;
+  last_name: string;
+  username: string;
+}
+
 // MARK: Authentication Methods
 export async function signup(
   details: SignupDetails,

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -49,9 +49,7 @@ export async function login(
   return response.data.key as string;
 }
 
-export async function getUser(
-  axios: AxiosInstance
-): Promise<UserRecord> {
+export async function getUser(axios: AxiosInstance): Promise<UserRecord> {
   const response = await axios.get("/auth/user/");
   return response.data as UserRecord;
 }

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -1,5 +1,12 @@
 import axios, { AxiosError } from "axios";
 
+export interface PaginatedList<T> {
+  id: number;
+  next: string;
+  previous: string;
+  results: Array<T>;
+}
+
 export function generateAxiosInstance(token?: string) {
   const instance = axios.create({
     baseURL: "http://127.0.0.1:8080/"

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -2,8 +2,8 @@ import axios, { AxiosError } from "axios";
 
 export interface PaginatedList<T> {
   id: number;
-  next: string;
-  previous: string;
+  next: string | null;
+  previous: string | null;
   results: Array<T>;
 }
 

--- a/src/api/statuses.ts
+++ b/src/api/statuses.ts
@@ -1,7 +1,8 @@
 import { AxiosInstance } from "axios";
-import { TeamRecord } from "@/api/teams";
+import { NewTeamRecord, TeamRecord } from "@/api/teams";
+import { PaginatedList } from "@/api/base";
 
-export interface NewStatusRecord {
+export interface WriteStatusRecord {
   title: string;
 }
 
@@ -25,12 +26,38 @@ export async function getStatus(
 export async function postStatus(
   axios: AxiosInstance,
   team: TeamRecord,
-  title: string
+  record: WriteStatusRecord
 ): Promise<StatusRecord> {
-  const record: NewStatusRecord = {
-    title
-  };
-
   const response = await axios.post(`/api/teams/${team.id}/statuses/`, record);
   return response.data as StatusRecord;
+}
+
+export async function listStatus(
+  axios: AxiosInstance,
+  team: TeamRecord,
+  page: number,
+): Promise<PaginatedList<StatusRecord>> {
+  const response = await axios.get(`/api/teams/${team.id}/statuses/?page=${page}`);
+  return response.data as PaginatedList<StatusRecord>;
+} 
+
+export async function updateStatus(
+  axios: AxiosInstance,
+  team: TeamRecord,
+  record: StatusRecord
+): Promise<StatusRecord> {
+  const updateRecord: WriteStatusRecord = {
+    title: record.title
+  };
+
+  const response = await axios.put(`/api/teams/${team.id}/statuses/${record.id}`, updateRecord);
+  return response.data as StatusRecord;
+}
+
+export async function deleteStatus(
+  axios: AxiosInstance,
+  team: TeamRecord,
+  record: StatusRecord
+): Promise<void> {
+  const reponse = await axios.delete(`/api/teams/${team.id}/statuses/${record.id}/`);
 }

--- a/src/api/statuses.ts
+++ b/src/api/statuses.ts
@@ -35,11 +35,13 @@ export async function postStatus(
 export async function listStatus(
   axios: AxiosInstance,
   team: TeamRecord,
-  page: number,
+  page: number
 ): Promise<PaginatedList<StatusRecord>> {
-  const response = await axios.get(`/api/teams/${team.id}/statuses/?page=${page}`);
+  const response = await axios.get(
+    `/api/teams/${team.id}/statuses/?page=${page}`
+  );
   return response.data as PaginatedList<StatusRecord>;
-} 
+}
 
 export async function updateStatus(
   axios: AxiosInstance,
@@ -50,7 +52,10 @@ export async function updateStatus(
     title: record.title
   };
 
-  const response = await axios.put(`/api/teams/${team.id}/statuses/${record.id}`, updateRecord);
+  const response = await axios.put(
+    `/api/teams/${team.id}/statuses/${record.id}`,
+    updateRecord
+  );
   return response.data as StatusRecord;
 }
 
@@ -59,5 +64,7 @@ export async function deleteStatus(
   team: TeamRecord,
   record: StatusRecord
 ): Promise<void> {
-  const reponse = await axios.delete(`/api/teams/${team.id}/statuses/${record.id}/`);
+  const reponse = await axios.delete(
+    `/api/teams/${team.id}/statuses/${record.id}/`
+  );
 }

--- a/src/api/tags.ts
+++ b/src/api/tags.ts
@@ -1,0 +1,8 @@
+export interface TagRecord {
+    id: number,
+    object_uuid: number,
+    title: string,
+    created: Date,
+    activated?: Date,
+    deactivated?: Date
+}

--- a/src/api/tags.ts
+++ b/src/api/tags.ts
@@ -1,3 +1,12 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import axios, { AxiosInstance } from "axios";
+import { TeamRecord } from "@/api/teams";
+import { generateAxiosInstance, PaginatedList } from "./base";
+
+export interface WriteTagRecord {
+    title: string
+}
+
 export interface TagRecord {
     id: number,
     object_uuid: number,
@@ -5,4 +14,51 @@ export interface TagRecord {
     created: Date,
     activated?: Date,
     deactivated?: Date
+}
+
+export async function createTag(
+    record: WriteTagRecord,
+    team: TeamRecord,
+    axios: AxiosInstance
+): Promise<TagRecord> {
+    const response = await axios.post(`/api/teams/${team.id}/tags/`, record);
+    return response.data as TagRecord;
+}
+
+export async function updateTag(
+    record: TagRecord,
+    team: TeamRecord,
+    axios: AxiosInstance
+): Promise<TagRecord> {
+    const updateRecord = {
+        title: record.title
+    };
+    const response = await axios.put(`/api/teams/${team.id}/tags/${record.id}`, updateRecord);
+    return response.data as TagRecord;
+}
+
+export async function getTag(
+    id: number,
+    team: TeamRecord,
+    axios: AxiosInstance
+): Promise<TagRecord> {
+    const response = await axios.get(`/api/teams/${team.id}/tags/${id}/`)
+    return response.data as TagRecord;
+}
+
+export async function listTag(
+    team: TeamRecord,
+    page: number,
+    axios: AxiosInstance
+): Promise<PaginatedList<TagRecord>> {
+    const response = await axios.get(`/api/teams/${team.id}/tags/?page=${page}`);
+    return response.data as PaginatedList<TagRecord>;
+} 
+
+export async function deleteTag(
+    record: TagRecord,
+    team: TeamRecord,
+    axios: AxiosInstance
+) {
+    const reponse = await axios.delete(`/api/teams/${team.id}/tags/${record.id}`);
 }

--- a/src/api/tags.ts
+++ b/src/api/tags.ts
@@ -17,7 +17,7 @@ export interface TagRecord {
   deactivated?: DateTime;
 }
 
-interface ReadTagRecord {
+export interface ReadTagRecord {
   id: number;
   object_uuid: number;
   title: string;
@@ -26,17 +26,19 @@ interface ReadTagRecord {
   deactivated?: string;
 }
 
-function createTagRecord(
-  response: ReadTagRecord
-): TagRecord {
+export function createTagRecord(response: ReadTagRecord): TagRecord {
   return {
     id: response.id,
     object_uuid: response.object_uuid,
     title: response.title,
     created: DateTime.fromISO(response.created),
-    activated: response.activated? DateTime.fromISO(response.activated) : undefined,
-    deactivated: response.deactivated? DateTime.fromISO(response.deactivated) : undefined
-  }
+    activated: response.activated
+      ? DateTime.fromISO(response.activated)
+      : undefined,
+    deactivated: response.deactivated
+      ? DateTime.fromISO(response.deactivated)
+      : undefined
+  };
 }
 
 export async function createTag(
@@ -80,13 +82,11 @@ export async function listTag(
   const response = await axios.get(`/api/teams/${team.id}/tags/?page=${page}`);
 
   const listing: PaginatedList<ReadTagRecord> = response.data;
-  return { 
+  return {
     id: listing.id,
     next: listing.next,
     previous: listing.previous,
-    results: listing.results.map(
-      (elem) => createTagRecord(elem)
-    )
+    results: listing.results.map(elem => createTagRecord(elem))
   };
 }
 

--- a/src/api/tags.ts
+++ b/src/api/tags.ts
@@ -4,61 +4,64 @@ import { TeamRecord } from "@/api/teams";
 import { generateAxiosInstance, PaginatedList } from "./base";
 
 export interface WriteTagRecord {
-    title: string
+  title: string;
 }
 
 export interface TagRecord {
-    id: number,
-    object_uuid: number,
-    title: string,
-    created: Date,
-    activated?: Date,
-    deactivated?: Date
+  id: number;
+  object_uuid: number;
+  title: string;
+  created: Date;
+  activated?: Date;
+  deactivated?: Date;
 }
 
 export async function createTag(
-    record: WriteTagRecord,
-    team: TeamRecord,
-    axios: AxiosInstance
+  record: WriteTagRecord,
+  team: TeamRecord,
+  axios: AxiosInstance
 ): Promise<TagRecord> {
-    const response = await axios.post(`/api/teams/${team.id}/tags/`, record);
-    return response.data as TagRecord;
+  const response = await axios.post(`/api/teams/${team.id}/tags/`, record);
+  return response.data as TagRecord;
 }
 
 export async function updateTag(
-    record: TagRecord,
-    team: TeamRecord,
-    axios: AxiosInstance
+  record: TagRecord,
+  team: TeamRecord,
+  axios: AxiosInstance
 ): Promise<TagRecord> {
-    const updateRecord = {
-        title: record.title
-    };
-    const response = await axios.put(`/api/teams/${team.id}/tags/${record.id}`, updateRecord);
-    return response.data as TagRecord;
+  const updateRecord = {
+    title: record.title
+  };
+  const response = await axios.put(
+    `/api/teams/${team.id}/tags/${record.id}`,
+    updateRecord
+  );
+  return response.data as TagRecord;
 }
 
 export async function getTag(
-    id: number,
-    team: TeamRecord,
-    axios: AxiosInstance
+  id: number,
+  team: TeamRecord,
+  axios: AxiosInstance
 ): Promise<TagRecord> {
-    const response = await axios.get(`/api/teams/${team.id}/tags/${id}/`)
-    return response.data as TagRecord;
+  const response = await axios.get(`/api/teams/${team.id}/tags/${id}/`);
+  return response.data as TagRecord;
 }
 
 export async function listTag(
-    team: TeamRecord,
-    page: number,
-    axios: AxiosInstance
+  team: TeamRecord,
+  page: number,
+  axios: AxiosInstance
 ): Promise<PaginatedList<TagRecord>> {
-    const response = await axios.get(`/api/teams/${team.id}/tags/?page=${page}`);
-    return response.data as PaginatedList<TagRecord>;
-} 
+  const response = await axios.get(`/api/teams/${team.id}/tags/?page=${page}`);
+  return response.data as PaginatedList<TagRecord>;
+}
 
 export async function deleteTag(
-    record: TagRecord,
-    team: TeamRecord,
-    axios: AxiosInstance
+  record: TagRecord,
+  team: TeamRecord,
+  axios: AxiosInstance
 ) {
-    const reponse = await axios.delete(`/api/teams/${team.id}/tags/${record.id}`);
+  const reponse = await axios.delete(`/api/teams/${team.id}/tags/${record.id}`);
 }

--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -36,13 +36,13 @@ export async function createTeam(
 ): Promise<TeamRecord> {
   const newTeamRecord = await postTeam(record, axios);
 
-  try {
-    await postStatus(axios, newTeamRecord, "To Do");
-    await postStatus(axios, newTeamRecord, "In Progress");
-    await postStatus(axios, newTeamRecord, "Completed");
-  } catch (e) {
-    console.log("There was an error setting initial team status.");
-  }
+  // try {
+  //   await postStatus(axios, newTeamRecord, "To Do");
+  //   await postStatus(axios, newTeamRecord, "In Progress");
+  //   await postStatus(axios, newTeamRecord, "Completed");
+  // } catch (e) {
+  //   console.log("There was an error setting initial team status.");
+  // }
 
   return newTeamRecord;
 }

--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { AxiosInstance } from "axios";
 import { postStatus } from "@/api/statuses";
-import { DateTime } from 'luxon';
+import { DateTime } from "luxon";
 
 // Team API endpoints
 export interface NewTeamRecord {
@@ -31,9 +31,7 @@ export interface TeamRecord {
   deactivated?: DateTime;
 }
 
-function createTeamRecord(
-  response: ReadTeamRecord
-): TeamRecord {
+function createTeamRecord(response: ReadTeamRecord): TeamRecord {
   return {
     id: response.id,
     name: response.name,
@@ -41,9 +39,13 @@ function createTeamRecord(
     object_uuid: response.object_uuid,
     ticket_head: response.ticket_head,
     created: DateTime.fromISO(response.created),
-    activated: response.activated? DateTime.fromISO(response.activated) : undefined,
-    deactivated: response.deactivated? DateTime.fromISO(response.deactivated) : undefined
-  }
+    activated: response.activated
+      ? DateTime.fromISO(response.activated)
+      : undefined,
+    deactivated: response.deactivated
+      ? DateTime.fromISO(response.deactivated)
+      : undefined
+  };
 }
 
 export async function postTeam(
@@ -67,9 +69,9 @@ export async function createTeam(
   // TODO: tdimhcsleumas 3/2/2021 move this to the backend, after the
   // Tela deadline
   try {
-    await postStatus(axios, newTeamRecord, {title: "To Do"});
-    await postStatus(axios, newTeamRecord, {title: "In Progress"});
-    await postStatus(axios, newTeamRecord, {title: "Completed"});
+    await postStatus(axios, newTeamRecord, { title: "To Do" });
+    await postStatus(axios, newTeamRecord, { title: "In Progress" });
+    await postStatus(axios, newTeamRecord, { title: "Completed" });
   } catch (e) {
     console.log("There was an error setting initial team status.");
   }

--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -1,10 +1,23 @@
+/* eslint-disable @typescript-eslint/camelcase */
 import { AxiosInstance } from "axios";
 import { postStatus } from "@/api/statuses";
+import { DateTime } from 'luxon';
 
 // Team API endpoints
 export interface NewTeamRecord {
   name: string;
   description: string;
+}
+
+export interface ReadTeamRecord {
+  id: number;
+  name: string;
+  description: string;
+  object_uuid: string;
+  ticket_head: number;
+  created: string;
+  activated?: string;
+  deactivated?: string;
 }
 
 export interface TeamRecord {
@@ -13,9 +26,24 @@ export interface TeamRecord {
   description: string;
   object_uuid: string;
   ticket_head: number;
-  created: string;
-  activated: string;
-  deactivated: string;
+  created: DateTime;
+  activated?: DateTime;
+  deactivated?: DateTime;
+}
+
+function createTeamRecord(
+  response: ReadTeamRecord
+): TeamRecord {
+  return {
+    id: response.id,
+    name: response.name,
+    description: response.description,
+    object_uuid: response.object_uuid,
+    ticket_head: response.ticket_head,
+    created: DateTime.fromISO(response.created),
+    activated: response.activated? DateTime.fromISO(response.activated) : undefined,
+    deactivated: response.deactivated? DateTime.fromISO(response.deactivated) : undefined
+  }
 }
 
 export async function postTeam(
@@ -27,7 +55,7 @@ export async function postTeam(
     description: "UNUSED"
   });
 
-  return response.data as TeamRecord;
+  return createTeamRecord(response.data);
 }
 
 export async function createTeam(
@@ -36,13 +64,15 @@ export async function createTeam(
 ): Promise<TeamRecord> {
   const newTeamRecord = await postTeam(record, axios);
 
-  // try {
-  //   await postStatus(axios, newTeamRecord, "To Do");
-  //   await postStatus(axios, newTeamRecord, "In Progress");
-  //   await postStatus(axios, newTeamRecord, "Completed");
-  // } catch (e) {
-  //   console.log("There was an error setting initial team status.");
-  // }
+  // TODO: tdimhcsleumas 3/2/2021 move this to the backend, after the
+  // Tela deadline
+  try {
+    await postStatus(axios, newTeamRecord, {title: "To Do"});
+    await postStatus(axios, newTeamRecord, {title: "In Progress"});
+    await postStatus(axios, newTeamRecord, {title: "Completed"});
+  } catch (e) {
+    console.log("There was an error setting initial team status.");
+  }
 
   return newTeamRecord;
 }
@@ -52,5 +82,5 @@ export async function getTeam(
   teamId: number
 ): Promise<TeamRecord> {
   const response = await axios.get(`/api/teams/${teamId}/`);
-  return response.data as TeamRecord;
+  return createTeamRecord(response.data);
 }

--- a/src/api/tickets.ts
+++ b/src/api/tickets.ts
@@ -20,14 +20,14 @@ export interface TicketRecord {
     tag_list: Array<TagRecord>;
     owner: UserRecord;
     object_uuid: number;
-    assigned_user: UserRecord;
-    status: StatusRecord;
+    assigned_user: UserRecord | null;
+    status: StatusRecord | null;
     title: string;
     description: string;
-    comments: Array<number>; // TODO: tdimhcsleumas 2/22/2021, this will eventually change to a comment record
+    comments?: Array<number>; // TODO: tdimhcsleumas 2/22/2021, this will eventually change to a comment record
     created: Date; // TODO: convert these to datetime objects
-    activated: Date;
-    deactivated: Date;
+    activated?: Date;
+    deactivated?: Date;
 }
 
 const generateDetailUrl = (record: TicketRecord, team: TeamRecord) => {
@@ -57,13 +57,13 @@ export async function updateTicket(
        tag_list: record.tag_list.map(
            (elem) => elem.id
        ),
-       assigned_user: record.assigned_user.id,
-       status: record.status.id,
+       assigned_user: record.assigned_user?.id,
+       status: record.status?.id,
        title: record.title,
        description: record.description
     } as WriteTicketRecord;
 
-    const response = await axios.patch(generateDetailUrl(record, team), updateRecord);
+    const response = await axios.put(generateDetailUrl(record, team), updateRecord);
     return response.data as TicketRecord;
 }
 
@@ -82,9 +82,9 @@ export async function listTickets(
 ): Promise<PaginatedList<TicketRecord>> {
 
     let queryParams = `?page=${page}`;
-    if (filter?.assigned) queryParams += `assigned__username=${filter.assigned.username}`;
-    if (filter?.owner) queryParams += `owner__username=${filter.owner.username}`; 
-    if (filter?.search) queryParams += `search=${filter.search}`;
+    if (filter?.assigned) queryParams += `&assigned__username=${filter.assigned.username}`;
+    if (filter?.owner) queryParams += `&owner__username=${filter.owner.username}`; 
+    if (filter?.search) queryParams += `&search=${filter.search}`;
 
     const response = await axios.get(`/api/teams/${team.id}/tickets/${queryParams}`);
     return response.data as PaginatedList<TicketRecord>;

--- a/src/api/tickets.ts
+++ b/src/api/tickets.ts
@@ -1,14 +1,14 @@
+/* eslint-disable @typescript-eslint/camelcase */
 import { AxiosInstance } from "axios";
 import { StatusRecord } from "@/api/statuses";
 import { TeamRecord } from "@/api/teams";
 import { UserRecord } from "@/api/auth";
 import { PaginatedList } from "@/api/base";
+import { TagRecord } from "@/api/tags";
 
 export interface WriteTicketRecord {
-    tag_list: Array<Number>;
-    parent_id: number;
-    owner: UserRecord;
-    assigned_user: UserRecord;
+    tag_list: Array<number>;
+    assigned_user: number;
     status: number;
     title: string;
     description: string;
@@ -17,7 +17,7 @@ export interface WriteTicketRecord {
 export interface TicketRecord {
     id: number;
     ticket_number: number;
-    tag_list: Array<Number>;
+    tag_list: Array<TagRecord>;
     owner: UserRecord;
     object_uuid: number;
     assigned_user: UserRecord;
@@ -25,38 +25,70 @@ export interface TicketRecord {
     title: string;
     description: string;
     comments: Array<number>; // TODO: tdimhcsleumas 2/22/2021, this will eventually change to a comment record
-    created: string; // TODO: conver these to datetime objects
-    activated: string;
-    deactivated: string;
+    created: Date; // TODO: conver these to datetime objects
+    activated: Date;
+    deactivated: Date;
+}
+
+const generateDetailUrl = (record: TicketRecord, team: TeamRecord) => {
+    return `/api/teams/${team.id}/tickets/${record.id}/`;
+}
+
+const generateListUrl = (team: TeamRecord) => {
+    return `/api/teams/${team.id}/tickets/`
 }
 
 export async function createTicket(
-    record: TicketRecord,
-    team: TeamRecord,
-    axios: AxiosInstance
-): Promise<TicketRecord> {
-    const response = await axios.post(`/api/teams/${team.id}/tickets`, record); 
-    return response.data as TicketRecord;
-}
-
-export async function updateTicket(
-    id: number,
     record: WriteTicketRecord,
     team: TeamRecord,
     axios: AxiosInstance
 ): Promise<TicketRecord> {
-    const response = await axios.patch(`/api/teams/${team.id}/tickets/${id}/`, record);
+    const response = await axios.post(generateListUrl(team), record); 
+    return response.data as TicketRecord;
+}
+
+export async function updateTicket(
+    record: TicketRecord,
+    team: TeamRecord,
+    axios: AxiosInstance
+): Promise<TicketRecord> {
+
+    const updateRecord = {
+       tag_list: record.tag_list.map(
+           (elem) => elem.id
+       ),
+       assigned_user: record.assigned_user.id,
+       status: record.status.id,
+       title: record.title,
+       description: record.description
+    } as WriteTicketRecord;
+
+    const response = await axios.patch(generateDetailUrl(record, team), updateRecord);
     return response.data as TicketRecord;
 }
 
 export async function listTickets(
     team: TeamRecord,
+    page: number,
     axios: AxiosInstance
 ): Promise<PaginatedList<TicketRecord>> {
-    const response = await axios.get(`/api/teams/${team.id}/tickets/`);
+    const response = await axios.get(`/api/teams/${team.id}/tickets/?page=${page}`);
     return response.data as PaginatedList<TicketRecord>;
 }
 
+// export async function listOwnedTickets(
+    
+// ) {
+
+// }
+
+// export async function listAssignedTickets(
+
+// ) {
+
+// }
+
+// this will attach the list of subtickets, eventually
 export async function getTicket(
     id: number,
     team: TeamRecord,
@@ -71,5 +103,5 @@ export async function deleteTicket(
     team: TeamRecord,
     axios: AxiosInstance
 ): Promise<void> {
-    const response = await axios.delete(`/api/teams/${team.id}/tickets/${record.id}`);
+    const response = await axios.delete(generateDetailUrl(record, team));
 }

--- a/src/api/tickets.ts
+++ b/src/api/tickets.ts
@@ -7,91 +7,92 @@ import { PaginatedList } from "@/api/base";
 import { TagRecord } from "@/api/tags";
 
 export interface WriteTicketRecord {
-    tag_list: Array<number>;
-    assigned_user: number | undefined;
-    status: number | undefined;
-    title: string;
-    description: string;
+  tag_list: Array<number>;
+  assigned_user: number | undefined;
+  status: number | undefined;
+  title: string;
+  description: string;
 }
 
 export interface TicketRecord {
-    id: number;
-    ticket_number: number;
-    tag_list: Array<TagRecord>;
-    owner: UserRecord;
-    object_uuid: number;
-    assigned_user: UserRecord | null;
-    status: StatusRecord | null;
-    title: string;
-    description: string;
-    comments?: Array<number>; // TODO: tdimhcsleumas 2/22/2021, this will eventually change to a comment record
-    created: Date; // TODO: convert these to datetime objects
-    activated?: Date;
-    deactivated?: Date;
+  id: number;
+  ticket_number: number;
+  tag_list: Array<TagRecord>;
+  owner: UserRecord;
+  object_uuid: number;
+  assigned_user: UserRecord | null;
+  status: StatusRecord | null;
+  title: string;
+  description: string;
+  comments?: Array<number>; // TODO: tdimhcsleumas 2/22/2021, this will eventually change to a comment record
+  created: Date; // TODO: convert these to datetime objects
+  activated?: Date;
+  deactivated?: Date;
 }
 
 const generateDetailUrl = (record: TicketRecord, team: TeamRecord) => {
-    return `/api/teams/${team.id}/tickets/${record.id}/`;
-}
+  return `/api/teams/${team.id}/tickets/${record.id}/`;
+};
 
 const generateListUrl = (team: TeamRecord) => {
-    return `/api/teams/${team.id}/tickets/`
-}
+  return `/api/teams/${team.id}/tickets/`;
+};
 
 export async function createTicket(
-    record: WriteTicketRecord,
-    team: TeamRecord,
-    axios: AxiosInstance
+  record: WriteTicketRecord,
+  team: TeamRecord,
+  axios: AxiosInstance
 ): Promise<TicketRecord> {
-    const response = await axios.post(generateListUrl(team), record); 
-    return response.data as TicketRecord;
+  const response = await axios.post(generateListUrl(team), record);
+  return response.data as TicketRecord;
 }
 
 export async function updateTicket(
-    record: TicketRecord,
-    team: TeamRecord,
-    axios: AxiosInstance
+  record: TicketRecord,
+  team: TeamRecord,
+  axios: AxiosInstance
 ): Promise<TicketRecord> {
+  const updateRecord = {
+    tag_list: record.tag_list.map(elem => elem.id),
+    assigned_user: record.assigned_user?.id,
+    status: record.status?.id,
+    title: record.title,
+    description: record.description
+  } as WriteTicketRecord;
 
-    const updateRecord = {
-       tag_list: record.tag_list.map(
-           (elem) => elem.id
-       ),
-       assigned_user: record.assigned_user?.id,
-       status: record.status?.id,
-       title: record.title,
-       description: record.description
-    } as WriteTicketRecord;
-
-    const response = await axios.put(generateDetailUrl(record, team), updateRecord);
-    return response.data as TicketRecord;
+  const response = await axios.put(
+    generateDetailUrl(record, team),
+    updateRecord
+  );
+  return response.data as TicketRecord;
 }
 
 export interface FilterOptions {
-    search?: string;
-    owner?: UserRecord;
-    assigned?: UserRecord;
-} 
-
+  search?: string;
+  owner?: UserRecord;
+  assigned?: UserRecord;
+}
 
 export async function listTickets(
-    team: TeamRecord,
-    page: number,
-    axios: AxiosInstance,
-    filter?: FilterOptions
+  team: TeamRecord,
+  page: number,
+  axios: AxiosInstance,
+  filter?: FilterOptions
 ): Promise<PaginatedList<TicketRecord>> {
+  let queryParams = `?page=${page}`;
+  if (filter?.assigned)
+    queryParams += `&assigned__username=${filter.assigned.username}`;
+  if (filter?.owner) queryParams += `&owner__username=${filter.owner.username}`;
+  if (filter?.search) queryParams += `&search=${filter.search}`;
 
-    let queryParams = `?page=${page}`;
-    if (filter?.assigned) queryParams += `&assigned__username=${filter.assigned.username}`;
-    if (filter?.owner) queryParams += `&owner__username=${filter.owner.username}`; 
-    if (filter?.search) queryParams += `&search=${filter.search}`;
-
-    const response = await axios.get(`/api/teams/${team.id}/tickets/${queryParams}`);
-    return response.data as PaginatedList<TicketRecord>;
+  const response = await axios.get(
+    `/api/teams/${team.id}/tickets/${queryParams}`
+  );
+  return response.data as PaginatedList<TicketRecord>;
 }
 
 // export async function listOwnedTickets(
-    
+
 // ) {
 
 // }
@@ -104,18 +105,18 @@ export async function listTickets(
 
 // this will attach the list of subtickets, eventually
 export async function getTicket(
-    id: number,
-    team: TeamRecord,
-    axios: AxiosInstance
+  id: number,
+  team: TeamRecord,
+  axios: AxiosInstance
 ): Promise<TicketRecord> {
-    const response = await axios.get(`/api/teams/${team.id}/tickets/${id}/`);
-    return response.data as TicketRecord;
+  const response = await axios.get(`/api/teams/${team.id}/tickets/${id}/`);
+  return response.data as TicketRecord;
 }
 
 export async function deleteTicket(
-    record: TicketRecord,
-    team: TeamRecord,
-    axios: AxiosInstance
+  record: TicketRecord,
+  team: TeamRecord,
+  axios: AxiosInstance
 ): Promise<void> {
-    const response = await axios.delete(generateDetailUrl(record, team));
+  const response = await axios.delete(generateDetailUrl(record, team));
 }

--- a/src/api/tickets.ts
+++ b/src/api/tickets.ts
@@ -1,0 +1,75 @@
+import { AxiosInstance } from "axios";
+import { StatusRecord } from "@/api/statuses";
+import { TeamRecord } from "@/api/teams";
+import { UserRecord } from "@/api/auth";
+import { PaginatedList } from "@/api/base";
+
+export interface WriteTicketRecord {
+    tag_list: Array<Number>;
+    parent_id: number;
+    owner: UserRecord;
+    assigned_user: UserRecord;
+    status: number;
+    title: string;
+    description: string;
+}
+
+export interface TicketRecord {
+    id: number;
+    ticket_number: number;
+    tag_list: Array<Number>;
+    owner: UserRecord;
+    object_uuid: number;
+    assigned_user: UserRecord;
+    status: StatusRecord;
+    title: string;
+    description: string;
+    comments: Array<number>; // TODO: tdimhcsleumas 2/22/2021, this will eventually change to a comment record
+    created: string; // TODO: conver these to datetime objects
+    activated: string;
+    deactivated: string;
+}
+
+export async function createTicket(
+    record: TicketRecord,
+    team: TeamRecord,
+    axios: AxiosInstance
+): Promise<TicketRecord> {
+    const response = await axios.post(`/api/teams/${team.id}/tickets`, record); 
+    return response.data as TicketRecord;
+}
+
+export async function updateTicket(
+    id: number,
+    record: WriteTicketRecord,
+    team: TeamRecord,
+    axios: AxiosInstance
+): Promise<TicketRecord> {
+    const response = await axios.patch(`/api/teams/${team.id}/tickets/${id}/`, record);
+    return response.data as TicketRecord;
+}
+
+export async function listTickets(
+    team: TeamRecord,
+    axios: AxiosInstance
+): Promise<PaginatedList<TicketRecord>> {
+    const response = await axios.get(`/api/teams/${team.id}/tickets/`);
+    return response.data as PaginatedList<TicketRecord>;
+}
+
+export async function getTicket(
+    id: number,
+    team: TeamRecord,
+    axios: AxiosInstance
+): Promise<TicketRecord> {
+    const response = await axios.get(`/api/teams/${team.id}/tickets/${id}/`);
+    return response.data as TicketRecord;
+}
+
+export async function deleteTicket(
+    record: TicketRecord,
+    team: TeamRecord,
+    axios: AxiosInstance
+): Promise<void> {
+    const response = await axios.delete(`/api/teams/${team.id}/tickets/${record.id}`);
+}

--- a/src/api/tickets.ts
+++ b/src/api/tickets.ts
@@ -30,20 +30,12 @@ export interface TicketRecord {
   deactivated?: Date;
 }
 
-const generateDetailUrl = (record: TicketRecord, team: TeamRecord) => {
-  return `/api/teams/${team.id}/tickets/${record.id}/`;
-};
-
-const generateListUrl = (team: TeamRecord) => {
-  return `/api/teams/${team.id}/tickets/`;
-};
-
 export async function createTicket(
   record: WriteTicketRecord,
   team: TeamRecord,
   axios: AxiosInstance
 ): Promise<TicketRecord> {
-  const response = await axios.post(generateListUrl(team), record);
+  const response = await axios.post(`/api/teams/${team.id}/tickets/`, record);
   return response.data as TicketRecord;
 }
 
@@ -61,7 +53,7 @@ export async function updateTicket(
   } as WriteTicketRecord;
 
   const response = await axios.put(
-    generateDetailUrl(record, team),
+    `/api/teams/${team.id}/tickets/${record.id}/`,
     updateRecord
   );
   return response.data as TicketRecord;
@@ -118,5 +110,7 @@ export async function deleteTicket(
   team: TeamRecord,
   axios: AxiosInstance
 ): Promise<void> {
-  const response = await axios.delete(generateDetailUrl(record, team));
+  const response = await axios.delete(
+    `/api/teams/${team.id}/tickets/${record.id}/`
+  );
 }

--- a/src/api/tickets.ts
+++ b/src/api/tickets.ts
@@ -8,8 +8,8 @@ import { TagRecord } from "@/api/tags";
 
 export interface WriteTicketRecord {
     tag_list: Array<number>;
-    assigned_user: number;
-    status: number;
+    assigned_user: number | undefined;
+    status: number | undefined;
     title: string;
     description: string;
 }

--- a/src/api/tickets.ts
+++ b/src/api/tickets.ts
@@ -25,7 +25,7 @@ export interface TicketRecord {
     title: string;
     description: string;
     comments: Array<number>; // TODO: tdimhcsleumas 2/22/2021, this will eventually change to a comment record
-    created: Date; // TODO: conver these to datetime objects
+    created: Date; // TODO: convert these to datetime objects
     activated: Date;
     deactivated: Date;
 }
@@ -67,12 +67,26 @@ export async function updateTicket(
     return response.data as TicketRecord;
 }
 
+export interface FilterOptions {
+    search?: string;
+    owner?: UserRecord;
+    assigned?: UserRecord;
+} 
+
+
 export async function listTickets(
     team: TeamRecord,
     page: number,
-    axios: AxiosInstance
+    axios: AxiosInstance,
+    filter?: FilterOptions
 ): Promise<PaginatedList<TicketRecord>> {
-    const response = await axios.get(`/api/teams/${team.id}/tickets/?page=${page}`);
+
+    let queryParams = `?page=${page}`;
+    if (filter?.assigned) queryParams += `assigned__username=${filter.assigned.username}`;
+    if (filter?.owner) queryParams += `owner__username=${filter.owner.username}`; 
+    if (filter?.search) queryParams += `search=${filter.search}`;
+
+    const response = await axios.get(`/api/teams/${team.id}/tickets/${queryParams}`);
     return response.data as PaginatedList<TicketRecord>;
 }
 

--- a/src/components/TicketModal.vue
+++ b/src/components/TicketModal.vue
@@ -94,6 +94,16 @@ export default defineComponent({
       description: ""
     } as WriteTicketRecord);
 
+    const resetData = () => {
+      ticketRecord.value = {
+        tag_list: [],
+        assigned_user: undefined,
+        status: undefined,
+        title: "",
+        description: ""
+      };
+    }
+
     const submit = async () => {
       show.value = !show.value
       const axiosInstance = store.getters.generateAxiosInstance; 
@@ -101,11 +111,13 @@ export default defineComponent({
       console.log(props.team);
       const ticket = await createTicket(ticketRecord.value, props.team as TeamRecord, axiosInstance);
 
+      resetData();
       context.emit("create");
     }
 
     const cancel = () => {
       show.value = !show.value;
+      resetData();
     }
 
     onMounted(() => {

--- a/src/components/TicketModal.vue
+++ b/src/components/TicketModal.vue
@@ -109,10 +109,12 @@ export default defineComponent({
       const axiosInstance = store.getters.generateAxiosInstance; 
 
       console.log(props.team);
-      const ticket = await createTicket(ticketRecord.value, props.team as TeamRecord, axiosInstance);
-
-      resetData();
-      context.emit("create");
+      try {
+        await createTicket(ticketRecord.value, props.team as TeamRecord, axiosInstance);
+        context.emit("create");
+      } finally {
+        resetData();
+      }
     }
 
     const cancel = () => {
@@ -120,10 +122,6 @@ export default defineComponent({
       resetData();
     }
 
-    onMounted(() => {
-      console.log(props.team);
-    })
-    
     return {
       show,
       ticketRecord,

--- a/src/components/TicketModal.vue
+++ b/src/components/TicketModal.vue
@@ -1,6 +1,7 @@
 <template>
-  <div class="modal is-active">
-    <div class="modal-background" @click="close"></div>
+  <a @click="show = true"> <i class="fa fa-plus fa-fw"></i> Add a ticket ... </a>
+  <div v-if="show" class="modal is-active">
+    <div class="modal-background" @click="cancel"></div>
     <div class="modal-content new_ticket_modal">
       <section class="box ">
         <div class="columns">
@@ -10,6 +11,7 @@
               <input
                 type="text"
                 class="input"
+                v-model="ticketRecord.title"
                 placeholder="Enter new title here"
               />
               <span class="has-text-danger" v-if="text_error"
@@ -33,6 +35,7 @@
               <textarea
                 class="textarea is-fullwidth"
                 placeholder="Enter new ticket here"
+                v-model="ticketRecord.description"
               ></textarea>
               <span class="has-text-danger" v-if="text_type_error"
                 >Field must be Alphanumeric</span
@@ -55,7 +58,7 @@
             </div>
           </div>
         </div>
-        <button class="button is-success">Save changes</button>
+        <button class="button is-success" @click="submit">Save changes</button>
         <button class="button">Cancel</button>
       </section>
     </div>
@@ -63,12 +66,59 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+/* eslint-disable @typescript-eslint/camelcase */
+import { defineComponent, onMounted, ref } from "vue";
+import { TeamRecord } from "@/api/teams";
+import { WriteTicketRecord, createTicket } from "@/api/tickets";
+import store from "@/store";
 
 export default defineComponent({
-  name: "TicketModal"
-  // components: {
-  // }
+  name: "TicketModal",
+  props: {
+    team: {
+      type: Object,
+      required: true
+    } 
+  },
+  emits: [
+    "create"
+  ],
+  setup(props, context) {
+    const show = ref(false);
+
+    const ticketRecord = ref({
+      tag_list: [],
+      assigned_user: undefined,
+      status: undefined,
+      title: "",
+      description: ""
+    } as WriteTicketRecord);
+
+    const submit = async () => {
+      show.value = !show.value
+      const axiosInstance = store.getters.generateAxiosInstance; 
+
+      console.log(props.team);
+      const ticket = await createTicket(ticketRecord.value, props.team as TeamRecord, axiosInstance);
+
+      context.emit("create");
+    }
+
+    const cancel = () => {
+      show.value = !show.value;
+    }
+
+    onMounted(() => {
+      console.log(props.team);
+    })
+    
+    return {
+      show,
+      ticketRecord,
+      submit,
+      cancel
+    };
+  }
 });
 </script>
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,8 @@ import router from "./router";
 
 require("@/assets/common.scss");
 
+store.dispatch.attempt(localStorage.getItem('token'));
+
 createApp(App)
   .use(store.original)
   .use(router)

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -24,7 +24,8 @@ const routes: Array<RouteRecordRaw> = [
       {
         path: "tickets",
         name: "Tickets",
-        component: Tickets
+        component: Tickets,
+        props: true 
       },
       {
         path: "users",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -54,7 +54,7 @@ const {
     async attempt(ctxRaw, key: string | null) { // validate the token by fetching the user record
       const context = rootActionContext(ctxRaw);
 
-      let newKey = key ? key : undefined;
+      const newKey = key ? key : undefined;
       context.commit.setToken(newKey);
       const axios = generateAxiosInstance(newKey);
 

--- a/src/views/TicketDetails.vue
+++ b/src/views/TicketDetails.vue
@@ -170,8 +170,12 @@
 import { defineComponent } from "vue";
 
 export default defineComponent({
-  name: "Help"
-  // components: {
-  // }
+  name: "Help",
+  setup: function() {
+
+
+    return {
+    };
+  }
 });
 </script>

--- a/src/views/Tickets.vue
+++ b/src/views/Tickets.vue
@@ -24,16 +24,12 @@
       </div>
     </section>
 
-    <ticket-modal></ticket-modal>
 
     <!-- TODO: Samuel Schmidt 5 / 21 / 2020 move this into a vue component -->
     <section class="section">
       <div class="container has-background-light">
         <div class="section">
-          <a> <i class="fa fa-plus fa-fw"></i> Add a ticket ... </a>
-          <p class="has-text-danger">
-            <i class="fa fa-ban fa-fw"></i> Must be approved to add tickets ...
-          </p>
+          <ticket-modal v-bind:team="teamRecord" v-on:create="getTeamTickets"></ticket-modal>
         </div>
         <div class="section">
           <div v-for="ticket in ticketList.results" v-bind:key="ticket.id" class="box">
@@ -132,6 +128,7 @@ export default defineComponent({
     });
 
     return {
+      teamRecord,
       ticketList,
       listPage,
       getTeamTickets,

--- a/src/views/Tickets.vue
+++ b/src/views/Tickets.vue
@@ -53,11 +53,13 @@
                   </span>
                 </div>
                 <div
+                  v-for="tag in ticket.tag_list"
+                  v-bind:key="tag.id"
                   class="level-item"
                   style="max-width: 100px; word-wrap:break-word;"
                 >
                   <span class="tag has-background-grey-lighter">
-                    TAG NAME
+                    {{ tag.title }}
                   </span>
                 </div>
               </div>
@@ -83,6 +85,7 @@ import { listTickets, TicketRecord } from "@/api/tickets";
 import { PaginatedList } from "@/api/base";
 import { TeamRecord, getTeam } from "@/api/teams";
 import store from "@/store";
+import TicketModal from "@/components/TicketModal.vue";
 
 export default defineComponent({
   name: "Tickets",
@@ -91,6 +94,9 @@ export default defineComponent({
       type: String,
       required: true
     }
+  },
+  components: {
+    TicketModal
   },
   setup(props) {
     const teamRecord = ref({} as TeamRecord);
@@ -128,7 +134,8 @@ export default defineComponent({
     return {
       ticketList,
       listPage,
-      getTeamTickets
+      getTeamTickets,
+      getTeamRecord
     };
   }
 });

--- a/src/views/Tickets.vue
+++ b/src/views/Tickets.vue
@@ -102,24 +102,14 @@ export default defineComponent({
     const getTeamTickets = async () => {
       const axiosInstance = store.getters.generateAxiosInstance;
       const team = teamRecord.value;
-      if (team) {
-        console.log("there is a team!");
-        ticketList.value = await listTickets(team, listPage.value, axiosInstance);
-      } else {
-        console.log("no team!");
-      }
+      ticketList.value = await listTickets(team, listPage.value, axiosInstance);
     }
 
     const getTeamRecord = async () => {
       const axiosInstance = store.getters.generateAxiosInstance;
       const teamId = parseInt(props.teamId); 
       const team = await getTeam(axiosInstance, teamId); 
-      if (team) {
-        console.log("team loaded!");
-        teamRecord.value = team;
-      } else {
-        console.log("no such team!");
-      }
+      teamRecord.value = team;
     }
 
     onMounted(async () => {

--- a/src/views/Tickets.vue
+++ b/src/views/Tickets.vue
@@ -40,7 +40,7 @@
                   style="max-width: 500px; word-wrap: break-word"
                 >
                   <a class="title">
-                    <span>{{ ticket.ticket_number }} | {{ ticket.title }} </span>
+                    <span>{{ ticket.ticket_number }} | {{ ticket.title }} | {{ ticket.created.toLocaleString() }} </span>
                   </a>
                 </div>
                 <div class="level-item">
@@ -80,6 +80,7 @@ import { defineComponent, ref, onMounted } from "vue";
 import { listTickets, TicketRecord } from "@/api/tickets";
 import { PaginatedList } from "@/api/base";
 import { TeamRecord, getTeam } from "@/api/teams";
+import { DateTime } from "luxon";
 import store from "@/store";
 import TicketModal from "@/components/TicketModal.vue";
 

--- a/src/views/Tickets.vue
+++ b/src/views/Tickets.vue
@@ -36,7 +36,7 @@
           </p>
         </div>
         <div class="section">
-          <div class="box">
+          <div v-for="ticket in ticketList.results" v-bind:key="ticket.id" class="box">
             <div class="level">
               <div class="level-left">
                 <div
@@ -44,7 +44,7 @@
                   style="max-width: 500px; word-wrap: break-word"
                 >
                   <a class="title">
-                    <span>#ID | Ticket Title </span>
+                    <span>{{ ticket.ticket_number }} | {{ ticket.title }} </span>
                   </a>
                 </div>
                 <div class="level-item">
@@ -84,11 +84,33 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { defineComponent, ref, onMounted } from "vue";
+import { listTickets, TicketRecord } from "@/api/tickets";
+import { PaginatedList } from "@/api/base";
+import { TeamRecord } from "@/api/teams";
+import store from "@/store";
 
 export default defineComponent({
-  name: "Tickets"
-  // components: {
-  // }
+  name: "Tickets",
+  setup() {
+    const ticketList = ref({} as PaginatedList<TicketRecord>);
+    const listPage = ref(1);
+    const getTeamTickets = async () => {
+      const axiosInstance = store.getters.generateAxiosInstance;
+      const team = store.state.team;
+
+      if (team) {
+        console.log("no team!")
+        ticketList.value = await listTickets(team, listPage.value, axiosInstance);
+      }
+    }
+    onMounted(getTeamTickets);
+
+    return {
+      ticketList,
+      listPage,
+      getTeamTickets
+    };
+  }
 });
 </script>


### PR DESCRIPTION
- extended api module to encapsulate ticket endpoints
- did the same for tags and statues
- I have the token put in localStorage for the time being, but this should probably be set in a cookie
- I'm passing the teamId as a prop because setting the team in the keystore every refresh was making iterating slower
- First pass at ticket and ticketModel views are completed. Filtering and pagination features have yet to be realized in the front end.